### PR TITLE
make /latest work for plugins and core book

### DIFF
--- a/nginx.conf.sigil
+++ b/nginx.conf.sigil
@@ -54,6 +54,14 @@ server {
         rewrite ^ /5/en/ permanent;
     }
 
+    # Match /latest to the current version of the docs published
+    location ~ ^/latest/?$ {
+        rewrite ^/latest/?$ /5/en/index.html redirect;
+    }
+    location ~ ^/latest/(.*)$ {
+        rewrite ^/latest/(.*)$ /5/$1 redirect;
+    }
+
     #
     # Rewrite version roots to english
     #
@@ -147,6 +155,12 @@ server {
     location ~ ^/authentication/?$ {
         rewrite ^ /authentication/3/en/index.html redirect;
     }
+    location ~ ^/authentication/latest/?$ {
+        rewrite ^/authentication/latest/?$ /authentication/3/en/index.html redirect;
+    }
+    location ~ ^/authentication/latest/(.*)$ {
+        rewrite ^/authentication/latest/(.*)$ /authentication/3/$1 redirect;
+    }
     location ~ ^/authentication/(1|2|3)/?$ {
         rewrite ^/authentication/([^/]+) /authentication/$1/en/index.html redirect;
     }
@@ -174,6 +188,12 @@ server {
     }
     location ~ ^/authorization/?$ {
         rewrite ^ /authorization/3/en/index.html redirect;
+    }
+    location ~ ^/authorization/latest/?$ {
+        rewrite ^/authorization/latest/?$ /authorization/3/en/index.html redirect;
+    }
+    location ~ ^/authorization/latest/(.*)$ {
+        rewrite ^/authorization/latest/(.*)$ /authorization/3/$1 redirect;
     }
     location ~ ^/authorization/(1|2|3)/?$ {
         rewrite ^/authorization/([^/]+) /authorization/$1/en/index.html redirect;
@@ -203,6 +223,12 @@ server {
     location ~ ^/bake/?$ {
         rewrite ^ /bake/3/en/index.html redirect;
     }
+    location ~ ^/bake/latest/?$ {
+        rewrite ^/bake/latest/?$ /bake/3/en/index.html redirect;
+    }
+    location ~ ^/bake/latest/(.*)$ {
+        rewrite ^/bake/latest/(.*)$ /bake/3/$1 redirect;
+    }
     location ~ ^/bake/[123]/?$ {
         rewrite ^/bake/([^/]+) /bake/$1/en/index.html redirect;
     }
@@ -230,6 +256,12 @@ server {
     }
     location ~ ^/chronos/?$ {
         rewrite ^ /chronos/3/en/index.html redirect;
+    }
+    location ~ ^/chronos/latest/?$ {
+        rewrite ^/chronos/latest/?$ /chronos/3/en/index.html redirect;
+    }
+    location ~ ^/chronos/latest/(.*)$ {
+        rewrite ^/chronos/latest/(.*)$ /chronos/3/$1 redirect;
     }
     location ~ ^/chronos/[123]/?$ {
         rewrite ^/chronos/([^/]+) /chronos/$1/en/index.html redirect;
@@ -259,6 +291,12 @@ server {
     location ~ ^/debugkit/?$ {
         rewrite ^ /debugkit/5/en/index.html redirect;
     }
+    location ~ ^/debugkit/latest/?$ {
+        rewrite ^/debugkit/latest/?$ /debugkit/5/en/index.html redirect;
+    }
+    location ~ ^/debugkit/latest/(.*)$ {
+        rewrite ^/debugkit/latest/(.*)$ /debugkit/5/$1 redirect;
+    }
     location ~ ^/debugkit/[345]/?$ {
         rewrite ^/debugkit/([^/]+) /debugkit/$1/en/index.html redirect;
     }
@@ -285,6 +323,12 @@ server {
     }
     location ~ ^/elasticsearch/?$ {
         rewrite ^ /elasticsearch/4/en/index.html redirect;
+    }
+    location ~ ^/elasticsearch/latest/?$ {
+        rewrite ^/elasticsearch/latest/?$ /elasticsearch/4/en/index.html redirect;
+    }
+    location ~ ^/elasticsearch/latest/(.*)$ {
+        rewrite ^/elasticsearch/latest/(.*)$ /elasticsearch/4/$1 redirect;
     }
     location ~ ^/elasticsearch/[234]/?$ {
         rewrite ^/elasticsearch/([^/]+)/?$ /elasticsearch/$1/en/index.html redirect;
@@ -313,6 +357,12 @@ server {
     location ~ ^/migrations/?$ {
         rewrite ^ /migrations/4/en/index.html redirect;
     }
+    location ~ ^/migrations/latest/?$ {
+        rewrite ^/migrations/latest/?$ /migrations/4/en/index.html redirect;
+    }
+    location ~ ^/migrations/latest/(.*)$ {
+        rewrite ^/migrations/latest/(.*)$ /migrations/4/$1 redirect;
+    }
     location ~ ^/migrations/[234]/?$ {
         rewrite ^/migrations/([234])/?$ /migrations/$1/en/index.html redirect;
     }
@@ -339,6 +389,12 @@ server {
     location ~ ^/phinx/0/?$ {
         rewrite ^ /phinx/0/en/index.html redirect;
     }
+    location ~ ^/phinx/latest/?$ {
+        rewrite ^/phinx/latest/?$ /phinx/0/en/index.html redirect;
+    }
+    location ~ ^/phinx/latest/(.*)$ {
+        rewrite ^/phinx/latest/(.*)$ /phinx/0/$1 redirect;
+    }
     location ~ ^/phinx/0/([a-z][a-z])/?$ {
         rewrite ^/phinx/0/([^/]+) /phinx/0/$1/index.html redirect;
     }
@@ -353,6 +409,12 @@ server {
     }
     location ~ ^/queue/[12]/?$ {
         rewrite ^/queue/([12])/?$ /queue/$1/en/index.html redirect;
+    }
+    location ~ ^/queue/latest/?$ {
+        rewrite ^/queue/latest/?$ /queue/2/en/index.html redirect;
+    }
+    location ~ ^/queue/latest/(.*)$ {
+        rewrite ^/queue/latest/(.*)$ /queue/2/$1 redirect;
     }
     location ~ ^/queue/[12]/([a-z][a-z])/?$ {
         rewrite ^/queue/([12])/([^/]+) /queue/$1/$2/index.html redirect;


### PR DESCRIPTION
makes the following URLs work:

## Core Book

- https://book.cakephp.org/latest
- https://book.cakephp.org/latest/
- https://book.cakephp.org/latest/en/index.html (and anything else behind latest)

## Plugins

- https://book.cakephp.org/authentication/latest
- https://book.cakephp.org/authentication/latest/
- https://book.cakephp.org/authentication/latest/en/index.html (and anything else behind latest)

The only kind of messy thing is the fact, that each plugin has its own "latest" version